### PR TITLE
Add check to sns + sqs topics to not set message attributes if none set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.8.x
-  - 1.9.x
-  - 1.10.x
+  - 1.11.x
+  - 1.12.x
 
 go_import_path: github.com/zerofox-oss/go-aws-msg

--- a/Makefile
+++ b/Makefile
@@ -2,28 +2,17 @@ PACKAGES=$(shell go list ./...)
 
 all: lint test
 
-go-lint:
-	go get -u github.com/alecthomas/gometalinter
-	gometalinter --install --force
+init: tools
+	GO111MODULE=on go mod vendor
 
-lint: go-lint
-	gometalinter \
-		--disable-all \
-		--enable=gofmt \
-		--enable=goimports \
-		--enable=golint \
-		--enable=misspell \
-		--enable=vetshadow \
-		--tests \
-		./...
+lint: init
+	golangci-lint run ./... --enable-all --disable=lll,scopelint --skip-dirs=vendor
 
-test: vendor
+test: init
 	go test -race -v ./...
 
-vendor:
-	go get -u -v github.com/kardianos/govendor
-	govendor init
-	govendor fetch +m
+tools:
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.14.0
 
 fmt:
 	go fmt $(PACKAGES)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/zerofox-oss/go-aws-msg
+
+go 1.12
+
+require (
+	github.com/aws/aws-sdk-go v1.19.15
+	github.com/zerofox-oss/go-msg v0.0.0-20180410212047-e91d2656af54
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/aws/aws-sdk-go v1.19.15 h1:Ov8zxPunHxZFxrXBarqzkZBSZugJRzPgb4mfq/SyVgA=
+github.com/aws/aws-sdk-go v1.19.15/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/zerofox-oss/go-msg v0.0.0-20180410212047-e91d2656af54 h1:tN4Ogk7yrhM0OK9Qm+S7lH4AuuWrrqjJUJB6Wq8X1uY=
+github.com/zerofox-oss/go-msg v0.0.0-20180410212047-e91d2656af54/go.mod h1:NBoCg3XghNKMT2CBi/OWaQiq9o3gStfZoZbEKzQj0KY=

--- a/sns/topic.go
+++ b/sns/topic.go
@@ -208,15 +208,17 @@ func (w *MessageWriter) Close() error {
 	}
 	w.closed = true
 
-	attrs := buildSNSAttributes(w.Attributes())
-	snsPublishParams := &sns.PublishInput{
-		Message:           aws.String(string(w.buf.String())),
-		TopicArn:          aws.String(w.topicARN),
-		MessageAttributes: attrs,
+	params := &sns.PublishInput{
+		Message:  aws.String(string(w.buf.String())),
+		TopicArn: aws.String(w.topicARN),
 	}
 
-	log.Printf("[TRACE] writing to sns: %v", snsPublishParams)
-	_, err := w.snsClient.PublishWithContext(w.ctx, snsPublishParams)
+	if len(*w.Attributes()) > 0 {
+		params.MessageAttributes = buildSNSAttributes(w.Attributes())
+	}
+
+	log.Printf("[TRACE] writing to sns: %v", params)
+	_, err := w.snsClient.PublishWithContext(w.ctx, params)
 	return err
 }
 

--- a/sns/topic.go
+++ b/sns/topic.go
@@ -34,7 +34,7 @@ type Topic struct {
 func getConf(t *Topic) (*aws.Config, error) {
 	svc, ok := t.Svc.(*sns.SNS)
 	if !ok {
-		return nil, errors.New("Svc could not be casted to a SNS client")
+		return nil, errors.New("svc could not be casted to a SNS client")
 	}
 	return &svc.Client.Config, nil
 }
@@ -209,7 +209,7 @@ func (w *MessageWriter) Close() error {
 	w.closed = true
 
 	params := &sns.PublishInput{
-		Message:  aws.String(string(w.buf.String())),
+		Message:  aws.String(w.buf.String()),
 		TopicArn: aws.String(w.topicARN),
 	}
 

--- a/sns/topic_test.go
+++ b/sns/topic_test.go
@@ -65,7 +65,9 @@ func TestMessageWriter_WriteAndCloseReturnErrorAfterFirstClose(t *testing.T) {
 		<-svc.sentParamChan
 	}()
 
-	mw.Write([]byte("test"))
+	if _, err := mw.Write([]byte("test")); err != nil {
+		t.Fatalf("could not write message %s", err)
+	}
 	mw.Close()
 
 	if _, err := mw.Write([]byte("test2")); err != msg.ErrClosedMessageWriter {
@@ -133,7 +135,9 @@ func TestMessageWriter_CloseProperlyConstructsPublishInput(t *testing.T) {
 		control <- struct{}{}
 	}()
 
-	mw.Write(msg)
+	if _, err := mw.Write(msg); err != nil {
+		t.Fatalf("could not write message %s", err)
+	}
 	mw.Close()
 
 	<-control
@@ -196,7 +200,9 @@ func TestMessageWriter_Close_retryer(t *testing.T) {
 			defer cancel()
 			w := tpc.NewWriter(ctx)
 
-			w.Write([]byte("it's full of stars!"))
+			if _, err := w.Write([]byte("it's full of stars!")); err != nil {
+				t.Fatalf("could not write message %s", err)
+			}
 			err = w.Close()
 
 			if strings.Index(err.Error(), "InvalidClientTokenId: The security token included in the request is invalid") != 0 {

--- a/sqs/server_test.go
+++ b/sqs/server_test.go
@@ -72,7 +72,9 @@ func TestServer_Serve(t *testing.T) {
 
 	go func() {
 		r := &SimpleReceiver{t: t}
-		srv.Serve(r)
+		if err := srv.Serve(r); err != nil {
+			t.Errorf("server died %s", err)
+		}
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -122,7 +124,9 @@ func TestServer_Serve_retries(t *testing.T) {
 			}
 			defer func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-				srv.Shutdown(ctx)
+				if err := srv.Shutdown(ctx); err != nil {
+					t.Logf("server shutdown failed %s", err)
+				}
 				cancel()
 			}()
 
@@ -149,7 +153,9 @@ func TestServer_Concurrency(t *testing.T) {
 
 	go func() {
 		r := &SimpleReceiver{t: t}
-		srv.Serve(r)
+		if err := srv.Serve(r); err != nil {
+			t.Errorf("server died %s", err)
+		}
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -168,7 +174,9 @@ func TestServer_ServeFailingReceiver(t *testing.T) {
 
 	go func() {
 		r := &FailingReceiver{t: t}
-		srv.Serve(r)
+		if err := srv.Serve(r); err != nil {
+			t.Errorf("server died %s", err)
+		}
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -200,18 +208,6 @@ func TestServer_ConvertToMsgAttrs(t *testing.T) {
 	}
 }
 
-// Test Shutdown with a nil context.Context.
-func TestServer_ShutdownWithoutContext(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("We expected a panic, recover() was not nil")
-		}
-	}()
-
-	srv := &Server{}
-	srv.Shutdown(nil)
-}
-
 // Tests that ErrServerClosed when all go routines finish before the context
 // cancels.
 func TestServer_ShutdownClean(t *testing.T) {
@@ -222,7 +218,9 @@ func TestServer_ShutdownClean(t *testing.T) {
 
 	go func() {
 		r := &SimpleReceiver{t: t}
-		srv.Serve(r)
+		if err := srv.Serve(r); err != msg.ErrServerClosed {
+			t.Logf("server died %s", err)
+		}
 	}()
 
 	err := srv.Shutdown(ctx)
@@ -241,7 +239,9 @@ func TestServer_ShutdownHard(t *testing.T) {
 
 	go func() {
 		r := &SimpleReceiver{t: t}
-		srv.Serve(r)
+		if err := srv.Serve(r); err != msg.ErrServerClosed {
+			t.Logf("server died %s", err)
+		}
 	}()
 
 	err := srv.Shutdown(ctx)

--- a/sqs/topic.go
+++ b/sqs/topic.go
@@ -104,17 +104,18 @@ func (w *MessageWriter) Close() error {
 	}
 	w.closed = true
 
-	sqsParams := &sqs.SendMessageInput{
-		MessageBody:       aws.String(w.buf.String()),
-		QueueUrl:          aws.String(w.queueURL),
-		MessageAttributes: buildSQSAttributes(w.Attributes()),
+	params := &sqs.SendMessageInput{
+		MessageBody: aws.String(w.buf.String()),
+		QueueUrl:    aws.String(w.queueURL),
 	}
 
-	log.Printf("[TRACE] writing to sqs: %v", sqsParams)
-	if _, err := w.sqsClient.SendMessageWithContext(w.ctx, sqsParams); err != nil {
-		return err
+	if len(*w.Attributes()) > 0 {
+		params.MessageAttributes = buildSQSAttributes(w.Attributes())
 	}
-	return nil
+
+	log.Printf("[TRACE] writing to sqs: %v", params)
+	_, err := w.sqsClient.SendMessageWithContext(w.ctx, params)
+	return err
 }
 
 // buildSNSAttributes converts msg.Attributes into SQS message attributes.

--- a/sqs/topic.go
+++ b/sqs/topic.go
@@ -85,7 +85,7 @@ func (w *MessageWriter) Write(p []byte) (int, error) {
 	w.mux.Lock()
 	defer w.mux.Unlock()
 
-	if w.closed == true {
+	if w.closed {
 		return 0, msg.ErrClosedMessageWriter
 	}
 	return w.buf.Write(p)
@@ -99,7 +99,7 @@ func (w *MessageWriter) Close() error {
 	w.mux.Lock()
 	defer w.mux.Unlock()
 
-	if w.closed == true {
+	if w.closed {
 		return msg.ErrClosedMessageWriter
 	}
 	w.closed = true


### PR DESCRIPTION
- aws-sdk-go seems to complain if sqs.SendMessageInput.MessageAttributes
  is empty. This check will omit the field if no attributes are set.