### PR TITLE
Add SetDelay func to sqs.MessageWriter

### DIFF
--- a/sqs/topic_test.go
+++ b/sqs/topic_test.go
@@ -1,0 +1,30 @@
+package sqs
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSetDelay(t *testing.T) {
+	durations := map[time.Duration]int64{
+		60 * time.Second: 60,
+
+		// round down to nearest second
+		3602 * time.Millisecond: 3,
+
+		// durations must be between 0 and 900
+		1200 * time.Second: 900,
+		-100 * time.Second: 0,
+	}
+
+	for d, seconds := range durations {
+		t.Run(d.String(), func(t *testing.T) {
+			w := &MessageWriter{}
+			w.SetDelay(d)
+
+			if w.delaySeconds != seconds {
+				t.Errorf("expected delay to be set to %d, got %d", seconds, w.delaySeconds)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Allows clients to set DelaySeconds on an SQS message,
  which is an AWS-specific feature.

- Default behavior stays the same, which is 0sec delay.