### PR TITLE
Add retryJitter option to add jitter to retryTimeout

### DIFF
--- a/sqs/mock.go
+++ b/sqs/mock.go
@@ -110,6 +110,7 @@ func newMockServer(concurrency int, mockSQS *mockSQSAPI) *Server {
 		serverCancelFunc:      serverCancelFunc,
 		QueueURL:              "https://myqueue.com",
 		Svc:                   mockSQS,
+		retryTimeout:          100,
 	}
 
 	return srv


### PR DESCRIPTION
Adds an option to randomly spread the retryTimeout over a window between
retryTimeout ± retryJitter.